### PR TITLE
Fix explorer read rbac collision

### DIFF
--- a/admin/src/pages/Explorer/index.tsx
+++ b/admin/src/pages/Explorer/index.tsx
@@ -63,7 +63,7 @@
             // Filter out content types that the user doesn't have the permission to access
             .filter(contentType =>
               allPermissions.some((permission: any) =>
-                permission.action === `plugin::${PLUGIN_ID}.explorer.read` &&
+                permission.action === `plugin::${PLUGIN_ID}.explorer.view-deleted` &&
                 permission.subject === contentType.uid
               )
             )
@@ -84,7 +84,7 @@
             // Filter out content types that the user doesn't have the permission to access
             .filter(contentType =>
               allPermissions.some((permission: any) =>
-                permission.action === `plugin::${PLUGIN_ID}.explorer.read` &&
+                permission.action === `plugin::${PLUGIN_ID}.explorer.view-deleted` &&
                 permission.subject === contentType.uid
               )
             )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "strapi-plugin-soft-delete-contents",
-  "version": "0.0.0",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "strapi-plugin-soft-delete-contents",
-      "version": "0.0.0",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@strapi/design-system": "^2.0.0-rc.23",
@@ -4465,18 +4465,6 @@
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/@strapi/content-manager/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
     "node_modules/@strapi/content-manager/node_modules/http-errors": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
@@ -4780,18 +4768,6 @@
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/@strapi/content-releases/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
     "node_modules/@strapi/content-releases/node_modules/intl-messageformat": {
       "version": "10.5.11",
       "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.11.tgz",
@@ -5020,18 +4996,6 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@strapi/content-type-builder/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@strapi/content-type-builder/node_modules/intl-messageformat": {
@@ -5500,18 +5464,6 @@
         "styled-components": "^6.0.0"
       }
     },
-    "node_modules/@strapi/design-system/node_modules/@types/react": {
-      "version": "18.3.20",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
-      "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/@strapi/design-system/node_modules/react-remove-scroll": {
       "version": "2.5.10",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
@@ -5861,18 +5813,6 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@strapi/i18n/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@strapi/i18n/node_modules/intl-messageformat": {
@@ -6247,18 +6187,6 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@strapi/review-workflows/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@strapi/review-workflows/node_modules/intl-messageformat": {
@@ -7497,18 +7425,6 @@
         "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/@strapi/ui-primitives/node_modules/@types/react": {
-      "version": "18.3.20",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
-      "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/@strapi/ui-primitives/node_modules/react-remove-scroll": {
       "version": "2.5.10",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
@@ -7665,18 +7581,6 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@strapi/upload/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@strapi/upload/node_modules/intl-messageformat": {

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -43,6 +43,15 @@ export default async ({ strapi }: { strapi: Core.Strapi & { admin: any } }) => {
   // Setup Permissions
   strapi.admin.services.permission.actionProvider.get('plugin::content-manager.explorer.delete').displayName = 'Soft Delete';
 
+  // Migration: rename explorer.read → explorer.view-deleted in any existing admin_permissions rows
+  const migrationReadViewDeletedRan = await pluginStore.get({ key: 'migration_explorer_read_to_view_deleted' });
+  if (!migrationReadViewDeletedRan) {
+    await strapi.db.connection('admin_permissions')
+      .where({ action: 'plugin::soft-delete.explorer.read' })
+      .update({ action: 'plugin::soft-delete.explorer.view-deleted' });
+    await pluginStore.set({ key: 'migration_explorer_read_to_view_deleted', value: true });
+  }
+
   const contentTypeUids = Object.keys(strapi.contentTypes).filter(supportsContentType);
 
   strapi.admin.services.permission.actionProvider.register({
@@ -60,7 +69,7 @@ export default async ({ strapi }: { strapi: Core.Strapi & { admin: any } }) => {
   });
 
   strapi.admin.services.permission.actionProvider.register({
-    uid: 'explorer.read',
+    uid: 'explorer.view-deleted',
     options: { applyToProperties: [ 'locales' ] },
     section: 'contentTypes',
     displayName: 'Deleted Read',

--- a/server/src/policies/adminCanRead.ts
+++ b/server/src/policies/adminCanRead.ts
@@ -2,5 +2,5 @@ import { PLUGIN_ID } from "../../../utils/plugin";
 
 export default (policyContext, config, { strapi }) => {
   const { userAbility } = policyContext.state;
-  return userAbility.can(`plugin::${PLUGIN_ID}.explorer.read`, policyContext.params.uid);
+  return userAbility.can(`plugin::${PLUGIN_ID}.explorer.view-deleted`, policyContext.params.uid);
 };


### PR DESCRIPTION
## Problem

Installing this plugin breaks the Strapi admin for **every content type** — Super Admins lose the ability to see or edit **any field** after installation.

**Root cause:** Strapi core's `DocumentRBAC.js` groups permissions by the last dot-segment of the action string (`read`, `create`, `update`, etc.), not the full qualified name. This plugin registered its action as `explorer.read`, which collides with Strapi's own `plugin::content-manager.explorer.read` under the same `"read"` bucket. Because the plugin's permission entry has no `properties.fields` (it's a whole-subject grant), `extractAndDedupeFields` collapses the merged result to `[]` — interpreted as "no fields allowed."

## Fix

Rename `explorer.read` → `explorer.view-deleted` so it no longer collides with Strapi's `read` suffix. `explorer.restore` and `explorer.delete-permanently` are fine as-is since they don't conflict with any Strapi core suffix.

### Migration

A one-time bootstrap migration renames any existing `admin_permissions` rows from the old action string to the new one, gated behind a plugin-store flag so it only runs once.

### Files changed

| File | Change |
|---|---|
| `server/src/bootstrap.ts` | Rename action registration + add gated migration |
| `server/src/policies/adminCanRead.ts` | Update permission check string |
| `admin/src/pages/Explorer/index.tsx` | Update two filter checks |
